### PR TITLE
RelationProvider now uses yii\gii\generators\model\Generator:generate…

### DIFF
--- a/crud/Generator.php
+++ b/crud/Generator.php
@@ -19,6 +19,7 @@ use yii\db\ActiveRecord;
 use yii\db\ColumnSchema;
 use yii\helpers\Inflector;
 use yii\helpers\Json;
+use \schmunk42\giiant\model\Generator as ModelGenerator;
 
 /**
  * This generator generates an extended version of CRUDs.
@@ -284,7 +285,8 @@ class Generator extends \yii\gii\generators\crud\Generator
                     }
 
                     if (in_array($relationType, $types)) {
-                        $stack[substr($method->name, 3)] = $relation;
+                        $name = ModelGenerator::generateRelationName([$relation], $model->getTableSchema(), substr($method->name, 3), $relation->multiple);
+                        $stack[$name] = $relation;
                     }
                 }
             } catch (Exception $e) {

--- a/crud/providers/RelationProvider.php
+++ b/crud/providers/RelationProvider.php
@@ -11,6 +11,7 @@ namespace schmunk42\giiant\crud\providers;
 use yii\db\ActiveRecord;
 use yii\db\ColumnSchema;
 use yii\helpers\Inflector;
+use \schmunk42\giiant\model\Generator as ModelGenerator;
 
 class RelationProvider extends \schmunk42\giiant\base\Provider
 {
@@ -106,7 +107,8 @@ EOS;
             }
             $title           = $this->generator->getModelNameAttribute($relation->modelClass);
             $route           = $this->generator->createRelationRoute($relation, 'view');
-            $relationGetter  = 'get' . $this->id2entity($column->name) . '()';
+            $modelClass      = $this->generator->modelClass;
+            $relationGetter  = 'get' . ModelGenerator::generateRelationName([$relation], $modelClass::getTableSchema(), $column->name, $relation->multiple) . '()';
             $params          = "'id' => \$model->{$column->name}";
             $relationModel   = new $relation->modelClass;
             $pks             = $relationModel->primaryKey();
@@ -160,7 +162,8 @@ EOS;
             $title           = $this->generator->getModelNameAttribute($relation->modelClass);
             $route           = $this->generator->createRelationRoute($relation, 'view');
             $method          = __METHOD__;
-            $relationGetter  = 'get' . $this->id2entity($column->name) . '()';
+            $modelClass      = $this->generator->modelClass;
+            $relationGetter  = 'get' . ModelGenerator::generateRelationName([$relation], $modelClass::getTableSchema(), $column->name, $relation->multiple) . '()';
             $relationModel   = new $relation->modelClass;
             $pks             = $relationModel->primaryKey();
             $paramArrayItems = "";
@@ -314,34 +317,5 @@ EOS;
 EOS;
         $code .= ' . \'</div>\' ';
         return $code;
-    }
-
-    /**
-     * Detects the entity name from the foreign key column name
-     * e.g. user_id | UserId | userId   -> User
-     *
-     * @param $column
-     *
-     * @return null|string
-     */
-    private function id2entity($column)
-    {
-        $entity = null;
-        switch (true) {
-            case (substr($column, -3, 3) == '_id'):
-                $entity = Inflector::id2camel(str_replace('_id', '', $column), '_');
-                break;
-            case (substr($column, -2, 2) == 'Id'):
-                $entity = Inflector::id2camel(substr($column, 0, strlen($column) - 2), '_');
-                break;
-            default:
-                // TODO: still improve detection for case when column name does not derive from table name, e.g. for CamelCase
-                //
-                // the behavior below is testes with a model with a FK -> PK column `foo_bar`,
-                // which is transformed to a getter `getFooBar()` by gii
-                $entity = Inflector::id2camel($column,'_');
-                break;
-        }
-        return $entity;
     }
 }

--- a/model/Generator.php
+++ b/model/Generator.php
@@ -212,6 +212,14 @@ class Generator extends \yii\gii\generators\model\Generator
         return $this->classNames2[$tableName] = $returnName;
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function generateRelationName($relations, $table, $key, $multiple)
+    {
+        return parent::generateRelationName($relations, $table, $key, $multiple);
+    }
+
     protected function generateRelations()
     {
         $relations = parent::generateRelations();


### PR DESCRIPTION
…RelationName() function to generate relation getters' names.